### PR TITLE
Implement Debug Mode in Aider Desk

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -3,7 +3,7 @@ import { LlmProvider } from '@common/llm-providers';
 import type { CoreMessage } from 'ai';
 import type { JsonSchema } from '@n8n/json-schema-to-zod';
 
-export type Mode = 'code' | 'ask' | 'architect' | 'context' | 'agent';
+export type Mode = 'code' | 'ask' | 'architect' | 'context' | 'agent' | 'debug';
 
 export type EditFormat = 'diff' | 'diff-fenced' | 'whole' | 'udiff' | 'udiff-simple' | 'patch';
 
@@ -112,6 +112,15 @@ export interface WindowState {
   isMaximized: boolean;
 }
 
+/**
+ * Structure for debug session state.
+ * Extend with additional debug-specific fields as needed.
+ */
+export interface DebugSession {
+  isActive: boolean;
+  // Additional debug-specific fields to be implemented in future PRs
+}
+
 export interface ProjectSettings {
   mainModel: string;
   weakModel?: string | null;
@@ -121,6 +130,7 @@ export interface ProjectSettings {
   thinkingTokens?: string;
   currentMode: Mode;
   renderMarkdown: boolean;
+  debugSession?: DebugSession;
 }
 
 export interface ProjectData {

--- a/src/renderer/src/components/ModeSelector.tsx
+++ b/src/renderer/src/components/ModeSelector.tsx
@@ -4,6 +4,7 @@ import { FaRegQuestionCircle } from 'react-icons/fa';
 import { AiOutlineFileSearch } from 'react-icons/ai';
 import { RiRobot2Line } from 'react-icons/ri';
 import { GoProjectRoadmap } from 'react-icons/go';
+import { BsBug } from 'react-icons/bs';
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/md';
 import { Mode } from '@common/types';
 import { useTranslation } from 'react-i18next';
@@ -44,9 +45,14 @@ const MODE_CONFIG: Record<Mode, ModeConfig> = {
     labelKey: 'mode.context',
     tooltipKey: 'modeTooltip.context',
   },
+  debug: {
+    icon: BsBug,
+    labelKey: 'mode.debug',
+    tooltipKey: 'modeTooltip.debug',
+  },
 };
 
-const MODES_ORDER: Mode[] = ['code', 'agent', 'ask', 'architect', 'context'];
+const MODES_ORDER: Mode[] = ['code', 'agent', 'ask', 'architect', 'context', 'debug'];
 
 type Props = {
   mode: Mode;

--- a/src/renderer/src/components/project/ProjectBar.tsx
+++ b/src/renderer/src/components/project/ProjectBar.tsx
@@ -7,6 +7,7 @@ import { IoMdClose } from 'react-icons/io';
 import { MdHistory } from 'react-icons/md';
 import { IoLogoMarkdown } from 'react-icons/io5';
 import { RiRobot2Line } from 'react-icons/ri';
+import { BsBug } from 'react-icons/bs';
 import { useTranslation } from 'react-i18next';
 import { getActiveProvider } from '@common/llm-providers';
 
@@ -232,49 +233,58 @@ export const ProjectBar = React.forwardRef<ProjectTopBarRef, Props>(
           </div>
         ) : (
           <div className="flex items-center h-full">
-            <div className="flex-grow flex items-center space-x-3">
-              {mode === 'agent' && settings?.agentConfig ? (
-                getActiveProvider(settings.agentConfig.providers) ? (
+              <div className="flex-grow flex items-center space-x-3">
+                {mode === 'agent' && settings?.agentConfig ? (
+                  getActiveProvider(settings.agentConfig.providers) ? (
+                    <>
+                      <div className="flex items-center space-x-1">
+                        <RiRobot2Line className="w-4 h-4 text-neutral-100 mr-1" data-tooltip-id="agent-tooltip" />
+                        <StyledTooltip id="agent-tooltip" content={t('modelSelector.agentModel')} />
+                        <AgentModelSelector />
+                      </div>
+                      <div className="h-3 w-px bg-neutral-600/50"></div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex items-center space-x-1 text-xs text-neutral-400">
+                        <RiRobot2Line className="w-4 h-4 text-neutral-100 mr-1" />
+                        <span>{t('modelSelector.noActiveAgentProvider')}</span>
+                      </div>
+                      <div className="h-3 w-px bg-neutral-600/50"></div>
+                    </>
+                  )
+                ) : mode === 'debug' ? (
                   <>
                     <div className="flex items-center space-x-1">
-                      <RiRobot2Line className="w-4 h-4 text-neutral-100 mr-1" data-tooltip-id="agent-tooltip" />
-                      <StyledTooltip id="agent-tooltip" content={t('modelSelector.agentModel')} />
-                      <AgentModelSelector />
+                      <BsBug className="w-4 h-4 text-neutral-100 mr-1" data-tooltip-id="debug-controls-tooltip" />
+                      <StyledTooltip id="debug-controls-tooltip" content={t('mode.debug')} />
+                      <DebugControls />
                     </div>
                     <div className="h-3 w-px bg-neutral-600/50"></div>
                   </>
                 ) : (
                   <>
-                    <div className="flex items-center space-x-1 text-xs text-neutral-400">
-                      <RiRobot2Line className="w-4 h-4 text-neutral-100 mr-1" />
-                      <span>{t('modelSelector.noActiveAgentProvider')}</span>
-                    </div>
-                    <div className="h-3 w-px bg-neutral-600/50"></div>
+                    {mode === 'architect' && (
+                      <>
+                        <div className="flex items-center space-x-1">
+                          <GoProjectRoadmap
+                            className="w-4 h-4 text-neutral-100 mr-1"
+                            data-tooltip-id="architect-model-tooltip"
+                            data-tooltip-content={t('modelSelector.architectModel')}
+                          />
+                          <StyledTooltip id="architect-model-tooltip" />
+                          <ModelSelector
+                            ref={architectModelSelectorRef}
+                            models={allModels}
+                            selectedModel={modelsData.architectModel || modelsData.mainModel}
+                            onChange={updateArchitectModel}
+                          />
+                        </div>
+                        <div className="h-3 w-px bg-neutral-600/50"></div>
+                      </>
+                    )}
                   </>
-                )
-              ) : (
-                <>
-                  {mode === 'architect' && (
-                    <>
-                      <div className="flex items-center space-x-1">
-                        <GoProjectRoadmap
-                          className="w-4 h-4 text-neutral-100 mr-1"
-                          data-tooltip-id="architect-model-tooltip"
-                          data-tooltip-content={t('modelSelector.architectModel')}
-                        />
-                        <StyledTooltip id="architect-model-tooltip" />
-                        <ModelSelector
-                          ref={architectModelSelectorRef}
-                          models={allModels}
-                          selectedModel={modelsData.architectModel || modelsData.mainModel}
-                          onChange={updateArchitectModel}
-                        />
-                      </div>
-                      <div className="h-3 w-px bg-neutral-600/50"></div>
-                    </>
-                  )}
-                </>
-              )}
+                )}
               <div className="flex items-center space-x-1">
                 <CgTerminal className="w-4 h-4 text-neutral-100 mr-1" data-tooltip-id="main-model-tooltip" />
                 <StyledTooltip
@@ -355,3 +365,12 @@ export const ProjectBar = React.forwardRef<ProjectTopBarRef, Props>(
 );
 
 ProjectBar.displayName = 'ProjectTopBar';
+
+// DebugControls placeholder for Debug mode
+function DebugControls() {
+  return (
+    <div className="text-xs text-neutral-300" data-testid="debug-controls-placeholder">
+      Debug Mode Controls Placeholder
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new 'Debug' mode in the Aider Desk application, allowing users to select this mode via the `ModeSelector` component. The changes include:

1. **Type System Updates**: The `Mode` type has been extended to include 'debug', and a new `DebugSession` interface has been added to manage debug-specific state within `ProjectSettings`.

2. **Mode Configuration**: The `ModeSelector` component has been updated to include the new 'Debug' mode with an appropriate icon and localization keys.

3. **Project Integration**: The `ProjectBar` component now conditionally renders a placeholder for debug-specific controls when 'Debug' mode is active, ensuring that the UI reflects the current mode correctly.

4. **Testing Plan**: The implementation has been verified to ensure that the 'Debug' mode icon appears, updates the Redux store correctly, and that the `ProjectBar` displays the debug controls placeholder when in 'Debug' mode.

This implementation lays the groundwork for future enhancements related to debugging functionalities.

---

> This pull request was co-created with Cosine Genie

Original Task: [aider-desk/kyhrmopoh8jn](https://cosine.sh/dbesqkwbz6a0/aider-desk/task/kyhrmopoh8jn)
Author: Freddy Williams
